### PR TITLE
Allow Client#find to take options

### DIFF
--- a/lib/rsolr-ext/client.rb
+++ b/lib/rsolr-ext/client.rb
@@ -16,8 +16,10 @@ module RSolr::Ext::Client
     path = args.first.is_a?(String) ? args.shift : 'select'
     # remove the params - the first, if it is a Hash OR set default
     params = args.first.kind_of?(Hash) ? args.shift : {}
+    # everything that isn't params is opts
+    opts = args.first.kind_of?(Hash) ? args.shift : {}
     # send path, map params and send the rest of the args along
-    response = self.send_and_receive path, { :params => RSolr::Ext::Request.map(params) }
+    response = self.send_and_receive path, opts.merge({ :params => RSolr::Ext::Request.map(params) })
     RSolr::Ext::Response::Base.new(response, path, params)
   end
   

--- a/spec/rsolr-ext_spec.rb
+++ b/spec/rsolr-ext_spec.rb
@@ -33,6 +33,20 @@ describe RSolr::Ext do
       response.raw[:path].should match(/select/)
     end
 
+    it "should pass on the opts hash to the send_and_receive method" do
+      c = client
+      expected_response = { 'response' => { 'docs' => [] }, 'responseHeader' => {}}
+      # ok this is hacky... the raw method needs to go into a mixin dude
+      def expected_response.raw
+        {:path => 'select'}
+      end
+
+      c.should_receive(:send_and_receive).
+        with('select', {:params => { :q => '*:*' }, :method => :post}).
+          and_return(expected_response)
+      response = c.find 'select', { :q => '*:*'}, { :method => :post }
+    end
+
     it 'should be ok' do
       c = client
       c.should_receive(:send_and_receive).


### PR DESCRIPTION
I've added the ability for #find to pass the correct options hash to #send_and_receive. We needed to use #find with the :method as :post. This allows any of the options documented in #send_and_receive to be used.
