### PR TITLE
RSOLREXT-9: simulates a will_paginate list insufficiently

### DIFF
--- a/lib/rsolr-ext/response/docs.rb
+++ b/lib/rsolr-ext/response/docs.rb
@@ -1,56 +1,19 @@
+require 'will_paginate/collection'
+
 module RSolr::Ext::Response::Docs
-  
-  module Pageable
-    
-    attr_accessor :start, :per_page, :total
-    
-    # Returns the current page calculated from 'rows' and 'start'
-    # WillPaginate hook
-    def current_page
-      return 1 if start < 1
-      per_page_normalized = per_page < 1 ? 1 : per_page
-      @current_page ||= (start / per_page_normalized).ceil + 1
-    end
-    
-    # Calcuates the total pages from 'numFound' and 'rows'
-    # WillPaginate hook
-    def total_pages
-      @total_pages ||= per_page > 0 ? (total / per_page.to_f).ceil : 1
-    end
-    
-    # returns the previous page number or 1
-    # WillPaginate hook
-    def previous_page
-      @previous_page ||= (current_page > 1) ? current_page - 1 : 1
-    end
-    
-    # returns the next page number or the last
-    # WillPaginate hook
-    def next_page
-      @next_page ||= (current_page == total_pages) ? total_pages : current_page+1
-    end
-    
-    def has_next?
-      current_page < total_pages
-    end
-    
-    def has_previous?
-      current_page > 1
-    end
-    
-  end
   
   def self.extended(base)
     d = base['response']['docs']
     d.each{|doc| doc.extend RSolr::Ext::Doc }
-    d.extend Pageable
-    d.per_page = base.rows
-    d.start = base.start
-    d.total = base.total
   end
   
   def docs
-    response['docs']
+    per_page = [self.rows, 1].max
+    page = (self.start / per_page).ceil + 1
+
+    WillPaginate::Collection.create(page, per_page, self.total) do |pager|
+      pager.replace(response['docs'])
+    end
   end
   
 end

--- a/lib/rsolr-ext/response/docs.rb
+++ b/lib/rsolr-ext/response/docs.rb
@@ -8,11 +8,13 @@ module RSolr::Ext::Response::Docs
   end
   
   def docs
-    per_page = [self.rows, 1].max
-    page = (self.start / per_page).ceil + 1
+    @docs ||= begin
+      per_page = [self.rows, 1].max
+      page = (self.start / per_page).ceil + 1
 
-    WillPaginate::Collection.create(page, per_page, self.total) do |pager|
-      pager.replace(response['docs'])
+      WillPaginate::Collection.create(page, per_page, self.total) do |pager|
+        pager.replace(response['docs'])
+      end
     end
   end
   

--- a/spec/rsolr-ext_spec.rb
+++ b/spec/rsolr-ext_spec.rb
@@ -161,7 +161,7 @@ describe RSolr::Ext do
       r.ok?.should == true
       r.docs.size.should == 11
       r.params[:echoParams].should == 'EXPLICIT'
-      r.docs.previous_page.should == 1
+      r.docs.previous_page.should be_nil
       r.docs.next_page.should == 2
       #
       r.should be_a(RSolr::Ext::Response::Docs)


### PR DESCRIPTION
This is a patch to address issue #9 (https://github.com/mwmitchell/rsolr-ext/issues/9), where a Rsolr::Ext response was mocking a WillPaginate-compatible object. Under this patch, RSolr::Ext::Response::Docs#docs now returns a WillPaginate::Collection, likely the appropriate way to implement WillPaginate on non-ActiveRecord collections.

One possible regression (although unlikely to have many real consequences) is a request for RSolr::Ext::Response#response['docs'](using the Solr hash) is no longer a WillPaginate-compatible object. I believe the preferred way to access the response documents was using  RSolr::Ext::Response#docs (which does return the WillPaginate::Collection). 
