### PR TITLE
RSOLREXT-9: simulates a will_paginate list insufficiently (with #has_previous? and #has_next?)

### DIFF
--- a/lib/rsolr-ext/response/docs.rb
+++ b/lib/rsolr-ext/response/docs.rb
@@ -1,6 +1,16 @@
 require 'will_paginate/collection'
 
 module RSolr::Ext::Response::Docs
+
+  module Pageable
+    def has_next?
+      current_page < total_pages
+    end
+
+    def has_previous?
+      current_page > 1
+    end
+  end
   
   def self.extended(base)
     d = base['response']['docs']
@@ -14,6 +24,7 @@ module RSolr::Ext::Response::Docs
 
       WillPaginate::Collection.create(page, per_page, self.total) do |pager|
         pager.replace(response['docs'])
+        pager.extend Pageable
       end
     end
   end

--- a/spec/rsolr-ext_spec.rb
+++ b/spec/rsolr-ext_spec.rb
@@ -177,6 +177,8 @@ describe RSolr::Ext do
       r.params[:echoParams].should == 'EXPLICIT'
       r.docs.previous_page.should be_nil
       r.docs.next_page.should == 2
+      r.docs.has_previous?.should == false
+      r.docs.has_next?.should == true
       #
       r.should be_a(RSolr::Ext::Response::Docs)
       r.should be_a(RSolr::Ext::Response::Facets)


### PR DESCRIPTION
Not sure where the conversation on pull request #11 is going, but this addresses the backwards compatibility concerns.
