### PR TITLE
Add support for parsing Solr term vectors

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -108,7 +108,26 @@ RSolr::Ext decorates the normal output hash from RSolr and adds some helpful met
 
 You can access values in the response hash using symbols or strings.
 
-===Documents/Pagination
+===Term Vectors
+Each document will include (if available) the {term vectors}[http://wiki.apache.org/solr/TermVectorComponent] from the Solr query.
+
+  doc = response.docs[0]
+  doc.term_vectors[:field]["word"]
+  doc.term_vectors[:field]["word"][:tf] = Integer
+  doc.term_vectors[:field]["word"][:offsets] = Array<Range>
+  doc.term_vectors[:field]["word"][:offsets][0] = Range
+  # ...
+  doc.term_vectors[:field]["word"][:positions] = Array<Integer>
+  doc.term_vectors[:field]["word"][:positions][0] = Integer
+  # ...
+  doc.term_vectors[:field]["word"][:df] = Float
+  doc.term_vectors[:field]["word"][:tfidf] = Float
+  doc.term_vectors[:field]["otherword"]
+  # ...
+  doc.term_vectors[:other_field]
+  # ...
+
+===Pagination
 If you wanna paginate the documents:
   <%= will_paginate response.docs.will_paginate %>
 

--- a/lib/rsolr-ext/response.rb
+++ b/lib/rsolr-ext/response.rb
@@ -2,6 +2,7 @@ module RSolr::Ext::Response
   
   autoload :Docs, 'rsolr-ext/response/docs'
   autoload :Facets, 'rsolr-ext/response/facets'
+  autoload :TermVectors, 'rsolr-ext/response/term_vectors'
   autoload :Spelling, 'rsolr-ext/response/spelling'
   
   class Base < Mash
@@ -16,6 +17,7 @@ module RSolr::Ext::Response
       extend Response
       extend Docs
       extend Facets
+      extend TermVectors
       extend Spelling
     end
     

--- a/lib/rsolr-ext/response/term_vectors.rb
+++ b/lib/rsolr-ext/response/term_vectors.rb
@@ -1,0 +1,128 @@
+
+module RSolr::Ext::Doc::TermVectors
+  
+  # doc.term_vectors[:field]["word"]
+  # doc.term_vectors[:field]["word"][:tf] = Integer
+  # doc.term_vectors[:field]["word"][:offsets] = Array<Range>
+  # doc.term_vectors[:field]["word"][:offsets][0] = Range
+  # # ...
+  # doc.term_vectors[:field]["word"][:positions] = Array<Integer>
+  # doc.term_vectors[:field]["word"][:positions][0] = Integer
+  # # ...
+  # doc.term_vectors[:field]["word"][:df] = Float
+  # doc.term_vectors[:field]["word"][:tfidf] = Float
+  # doc.term_vectors[:field]["otherword"]
+  # # ...
+  # doc.term_vectors[:other_field]
+  # # ...
+  def term_vectors
+    return {} unless @term_vector_arrays
+    
+    @term_vectors ||= (
+      ret = {}
+      @term_vector_arrays.each do |field, array|
+        field_term_vectors = {}
+      
+        (0...array.length).step(2) do |i|
+          term = array[i]
+          term.force_encoding("UTF-8") if RUBY_VERSION >= "1.9.0"
+          attr_array = array[i + 1]
+          hash = {}
+      
+          (0...attr_array.length).step(2) do |j|
+            key = attr_array[j]
+            val = attr_array[j+1]
+        
+            case key
+            when 'tf'
+              hash[:tf] = Integer(val)
+            when 'offsets'
+              hash[:offsets] = []
+              (0...val.length).step(4) do |k|
+                s = Integer(val[k+1])
+                e = Integer(val[k+3])
+                hash[:offsets] << (s...e)
+              end
+            when 'positions'
+              hash[:positions] = []
+              (0...val.length).step(2) do |k|
+                p = Integer(val[k+1])
+                hash[:positions] << p
+              end
+            when 'df'
+              hash[:df] = Float(val)
+            when 'tf-idf'
+              hash[:tfidf] = Float(val)
+            end
+          end
+      
+          field_term_vectors[term] = hash
+        end
+      
+        ret[field.to_sym] = field_term_vectors
+      end
+      ret
+    )
+  end
+  
+end
+
+module RSolr::Ext::Response::TermVectors
+  
+  def self.extended(base)
+    return unless base['termVectors']
+    return unless base['response']['docs']
+    
+    documents = base['response']['docs']
+    
+    # Dig up the unique key field name
+    unique_field_name = nil
+    base['termVectors'].each_with_index do |x, i|
+      if x == 'uniqueKeyFieldName'
+        unique_field_name = base['termVectors'][i + 1]
+      end
+    end
+    
+    # Parse all of the term vector arrays
+    #
+    # Array format:
+    #
+    #   [ 'doc-N', [ 'uniqueKey', '(key value)', 
+    #     '(term vector field)', [
+    #       'term', [
+    #         'tf', 1,
+    #         'offsets', ['start', 100, 'end', 110],
+    #         'positions', ['position', 50],
+    #         'df', 1,
+    #         'tf-idf', 0.234],
+    #       'term2', ... ], ... ], ... ]
+    (0...base['termVectors'].length).step(2) do |i|
+      document_array = base['termVectors'][i + 1]
+      unique_key = document_array[1]
+      
+      # Find a document with that unique key
+      doc = documents.detect do |doc|
+        if unique_field_name
+          doc[unique_field_name] == unique_key
+        else
+          doc.has_value? unique_key
+        end
+      end      
+      next unless doc
+      
+      # Make a hash pointing fields to arrays
+      term_hash = {}
+      
+      (2...document_array.length).step(2) do |j|
+        term = document_array[j]
+        term_array = document_array[j + 1]
+        
+        term_hash[term] = term_array
+      end
+      
+      doc.instance_variable_set(:@term_vector_arrays, term_hash)
+      doc.extend RSolr::Ext::Doc::TermVectors
+    end
+  end
+  
+end

--- a/lib/rsolr-ext/response/term_vectors.rb
+++ b/lib/rsolr-ext/response/term_vectors.rb
@@ -77,10 +77,8 @@ module RSolr::Ext::Response::TermVectors
     
     # Dig up the unique key field name
     unique_field_name = nil
-    base['termVectors'].each_with_index do |x, i|
-      if x == 'uniqueKeyFieldName'
-        unique_field_name = base['termVectors'][i + 1]
-      end
+    if base['termVectors'][-2] == 'uniqueKeyFieldName'
+      unique_field_name = base['termVectors'][-1]
     end
     
     # Parse all of the term vector arrays
@@ -95,8 +93,12 @@ module RSolr::Ext::Response::TermVectors
     #         'positions', ['position', 50],
     #         'df', 1,
     #         'tf-idf', 0.234],
-    #       'term2', ... ], ... ], ... ]
-    (0...base['termVectors'].length).step(2) do |i|
+    #       'term2', ... ], ... ],
+    #   'uniqueKeyFieldName', '(field name)' ]
+    #
+    # The last two items in this array are 'uniqueKeyFieldName' 
+    # and the unique key, which we queried above.
+    (0...(base['termVectors'].length - 2)).step(2) do |i|
       document_array = base['termVectors'][i + 1]
       unique_key = document_array[1]
       

--- a/rsolr-ext.gemspec
+++ b/rsolr-ext.gemspec
@@ -24,6 +24,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '~> 0.9.2'
   s.add_development_dependency 'rdoc', '~> 3.9.4'
   s.add_development_dependency 'rspec', '~> 2.6.0'
-  s.add_development_dependency 'rcov'
 end
 

--- a/spec/rsolr-ext_spec.rb
+++ b/spec/rsolr-ext_spec.rb
@@ -329,6 +329,19 @@ describe RSolr::Ext do
       r = RSolr::Ext::Response::Base.new(raw_response, '/catalog', {})
       r.spelling.collation.should == 'dell ultrasharp'
     end
+    
+    it 'should parse the term vectors' do
+      raw_response = eval(mock_response_with_term_vectors)
+      r = RSolr::Ext::Response::Base.new(raw_response, '', {})
+      
+      r.docs[0].term_vectors[:fulltext]['cornell'][:tf].should == 3
+      r.docs[0].term_vectors[:fulltext]['vehrencampf'][:df].should == 1
+      r.docs[0].term_vectors[:fulltext]['cornell'][:offsets].should have(3).items
+      r.docs[0].term_vectors[:fulltext]['cornell'][:offsets][1].should == (475...482)
+      r.docs[0].term_vectors[:fulltext]['vehrencampf'][:positions].should have(1).items
+      r.docs[0].term_vectors[:fulltext]['vehrencampf'][:positions][0].should == 25
+      r.docs[0].term_vectors[:fulltext]['cornell'][:tfidf].should == 1.5
+    end
 
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,10 @@ RSpec.configure do |config|
   def mock_response_with_spellcheck_collation
     %|{'responseHeader'=>{'status'=>0,'QTime'=>3,'params'=>{'spellspellcheck.build'=>'true','spellcheck'=>'true','q'=>'hell','spellcheck.q'=>'hell ultrashar','wt'=>'ruby','spellcheck.collate'=>'true'}},'response'=>{'numFound'=>0,'start'=>0,'docs'=>[]},'spellcheck'=>{'suggestions'=>['hell',{'numFound'=>1,'startOffset'=>0,'endOffset'=>4,'suggestion'=>['dell']},'ultrashar',{'numFound'=>1,'startOffset'=>5,'endOffset'=>14,'suggestion'=>['ultrasharp']},'collation','dell ultrasharp']}}|
   end
-
+  
+  def mock_response_with_term_vectors
+    %|{'responseHeader'=>{'status'=>0,'QTime'=>5,'params'=>{'tv.all'=>'true','wt'=>'ruby','version'=>'2.2','rows'=>'1','q'=>'shasum:00972c5123877961056b21aea4177d0dc69c7318','qt'=>'fulltext'}},'response'=>{'numFound'=>1,'start'=>0,'docs'=>[{'shasum'=>'00972c5123877961056b21aea4177d0dc69c7318','doi'=>'10.1111/j.1439-0310.2008.01576.x','fulltext'=>'Ethology How Reliable are the Methods for Estimating Repertoire Size? Carlos A. Botero*,f,$, Andrew E. Mudgef, Amanda M. Koltz, Wesley M. Hochachkaf & Sandra L. Vehrencampf,- * Center for Ecological and Evolutionary Studies, University of Groningen, Groningen, The Netherlands f Cornell Laboratory of Ornithology, Ithaca, NY, USA J Instituto de Investigation en Recursos Biologicos Alexander von Humboldt, Bogota, Colombia  Department of Ecology and Evolutionary Biology, Cornell University, Ithaca, NY, USA - Department of Neurobiology and Behavior, Cornell University, Ithaca, NY, USA'}]},'termVectors'=>['doc-4',['uniqueKey','00972c5123877961056b21aea4177d0dc69c7318','fulltext',['cornell',['tf',3,'offsets',['start',281,'end',288,'start',475,'end',482,'start',554,'end',561],'positions',['position',39,'position',64,'position',74],'df',2,'tf-idf',1.5],'vehrencampf',['tf',1,'offsets',['start',163,'end',174],'positions',['position',25],'df',1,'tf-idf',1.0]]],'uniqueKeyFieldName','shasum']}|
+  end
+  
 end
 


### PR DESCRIPTION
The Solr term vector syntax is ridiculously arcane, and since I wrote up some code to parse it for a project of mine, I thought I'd contribute it here.

I've done my best to stick to "house style," let me know if you'd like this patch prepared in a different way.  I've got a module to mix into the Response class (as 'termVectors' lives in the response), and a module to mix into each document, which pulls out the term vector arrays from the response and turns them into some actually useful Ruby code.

I've also included a spec test, based on some of my own Solr data.
